### PR TITLE
#228 #230 Add hover props

### DIFF
--- a/packages/web/src/components/spa/HackAUBG/HackAUBG.jsx
+++ b/packages/web/src/components/spa/HackAUBG/HackAUBG.jsx
@@ -25,12 +25,14 @@ export const HackAUBG = () => {
             <NavBar
                 props={
                     new Props(
-                        anchorList,
-                        false,
-                        'rgba(0,0,0,.5)',
-                        true,
-                        '#222222',
-                        'red'
+                        anchorList, // list of anchors
+                        false, // hackAUBG button
+                        'rgba(0,0,0,.5)', // backgroundColor of desktop nav
+                        true, // fixed desktop nav
+                        '#222222', // mobile nav background when not opened (default transparent)
+                        'gray', // mobile nav backgroundColor
+                        'white', // anchor color
+                        'green' // anchor hover color
                     )
                 }
             />

--- a/packages/web/src/components/spa/HackAUBG/HackAUBG.jsx
+++ b/packages/web/src/components/spa/HackAUBG/HackAUBG.jsx
@@ -27,12 +27,13 @@ export const HackAUBG = () => {
                     new Props(
                         anchorList, // list of anchors
                         false, // hackAUBG button
-                        'rgba(0,0,0,.5)', // backgroundColor of desktop nav
-                        true, // fixed desktop nav
-                        '#222222', // mobile nav background when not opened (default transparent)
-                        'gray', // mobile nav backgroundColor
+                        'rgba(0,0,0,.5)', // desktop background color nav
+                        true, // sticky desktop nav
+                        '#222222', // mobile nav background color when not opened (default transparent)
+                        'gray', // mobile background color nav when opened
                         'white', // anchor color
-                        'green' // anchor hover color
+                        'green', // desktop anchor hover color
+                        'dark gray' // mobile anchor hover color
                     )
                 }
             />

--- a/packages/web/src/components/spa/HackAUBG/HackAUBG.jsx
+++ b/packages/web/src/components/spa/HackAUBG/HackAUBG.jsx
@@ -13,8 +13,6 @@ export const HackAUBG = () => {
 
     const anchorList = [
         new Anchor('About', '#AboutSection'),
-        // new Anchor('Events', '#events'),
-        // new Anchor('Articles', '#articles'),
         new Anchor('Schedule', '#team'),
         new Anchor('Grading criteria', 'jobs'),
         new Anchor('FAQ', 'jobs')

--- a/packages/web/src/components/spa/Navigation/DesktopNav/NavDesktop.jsx
+++ b/packages/web/src/components/spa/Navigation/DesktopNav/NavDesktop.jsx
@@ -37,6 +37,10 @@ export const NavDesktop = ({ props }) => {
         };
     };
 
+    const changeAnchorColor = (e, color) => {
+        e.target.style.color = color;
+    };
+
     return (
         <div className="navdesktop-container" style={stickyProps()}>
             <div className="navdesktop-logo" onClick={openHome}>
@@ -50,7 +54,17 @@ export const NavDesktop = ({ props }) => {
             <div className="navdesktop-buttons">
                 {props.anchorList.map((anchor, index) => (
                     <div className="navdesktop-navdivs" key={index}>
-                        <a href={anchor.endpoint} key={index}>
+                        <a
+                            href={anchor.endpoint}
+                            key={index}
+                            onMouseEnter={(e) => {
+                                changeAnchorColor(e, props.anchorHoverColor);
+                            }}
+                            onMouseLeave={(e) => {
+                                changeAnchorColor(e, props.anchorColor);
+                            }}
+                            style={{ color: props.anchorColor }}
+                        >
                             {anchor.name}
                         </a>
                     </div>

--- a/packages/web/src/components/spa/Navigation/MobileNav/NavMobile.jsx
+++ b/packages/web/src/components/spa/Navigation/MobileNav/NavMobile.jsx
@@ -120,7 +120,6 @@ export const NavMobile = ({ props }) => {
                                         closeMenu();
                                         makeBodyScrollable();
                                     }}
-                                    className=""
                                 >
                                     {anchor.name}
                                 </a>

--- a/packages/web/src/components/spa/Navigation/MobileNav/NavMobile.jsx
+++ b/packages/web/src/components/spa/Navigation/MobileNav/NavMobile.jsx
@@ -51,7 +51,10 @@ export const NavMobile = ({ props }) => {
     };
 
     return (
-        <div className="navmobile-body">
+        <div
+            className="navmobile-body"
+            style={{ '--anchorHoverColor': props.mobileAnchorHoverColor }}
+        >
             <div
                 className="navmobile-container"
                 style={{

--- a/packages/web/src/components/spa/Navigation/MobileNav/mobile_navbar.css
+++ b/packages/web/src/components/spa/Navigation/MobileNav/mobile_navbar.css
@@ -112,6 +112,10 @@
     text-decoration: none;
 }
 
+.navmobile-anchors-container a:hover {
+    color: var(--anchorHoverColor);
+}
+
 .navmobile-logo {
     height: 7.5vh;
     left: 2px;

--- a/packages/web/src/components/spa/Navigation/NavFactory.js
+++ b/packages/web/src/components/spa/Navigation/NavFactory.js
@@ -7,7 +7,8 @@ class Props {
         mobileHeader = false,
         mobileBgColor = '#050328',
         anchorColor = 'white',
-        anchorHoverColor = 'rgb(21, 76, 121)'
+        anchorHoverColor = 'rgb(21, 76, 121)',
+        mobileAnchorHoverColor = 'rgb(21, 76, 121)'
     ) {
         this.anchorList = anchorList;
         this.hasHackButton = hasHackButton;
@@ -17,6 +18,7 @@ class Props {
         this.mobileBgColor = mobileBgColor;
         this.anchorColor = anchorColor;
         this.anchorHoverColor = anchorHoverColor;
+        this.mobileAnchorHoverColor = mobileAnchorHoverColor;
     }
 }
 

--- a/packages/web/src/components/spa/Navigation/NavFactory.js
+++ b/packages/web/src/components/spa/Navigation/NavFactory.js
@@ -5,7 +5,9 @@ class Props {
         bgColor,
         isSticky,
         mobileHeader = false,
-        mobileBgColor = '#050328'
+        mobileBgColor = '#050328',
+        anchorColor = 'white',
+        anchorHoverColor = 'rgb(21, 76, 121)'
     ) {
         this.anchorList = anchorList;
         this.hasHackButton = hasHackButton;
@@ -13,6 +15,8 @@ class Props {
         this.isSticky = isSticky;
         this.mobileHeader = mobileHeader;
         this.mobileBgColor = mobileBgColor;
+        this.anchorColor = anchorColor;
+        this.anchorHoverColor = anchorHoverColor;
     }
 }
 


### PR DESCRIPTION
Added hover props for both mobile and desktop nav. Now almost everything is customizable. e.g. background color of both navs, sticky position of desktop nav, anchor colors when mobile or desktop and respectively hover color as well.