### PR TITLE
Add cleanup for _tests collection

### DIFF
--- a/packages/api/tests/hackathon_teams_test.go
+++ b/packages/api/tests/hackathon_teams_test.go
@@ -23,6 +23,7 @@ func SetHeaders(req *http.Request) {
 
 func TestTeamEndpoint(t *testing.T) {
 	// Set up
+	t.Cleanup(CleanUpCollection)
 	go app.StartApp()
 
 	time.Sleep(5 * time.Second)

--- a/packages/api/tests/utils.go
+++ b/packages/api/tests/utils.go
@@ -1,0 +1,15 @@
+package tests
+
+import (
+	"context"
+	"hub-backend/configs"
+	"time"
+)
+
+func CleanUpCollection() {
+	collection := configs.GetCollection(configs.DB, "_tests")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	collection.Drop(ctx)
+}


### PR DESCRIPTION
Adds a cleanup which drops the test collection and makes sure there are no leftover document entries in the DB after running the tests. This ensures we can create entries with the same data and don't get bad request responses from the API.