### PR TITLE
#447 removed unnecessary testing code from hackathon registration controller

### DIFF
--- a/packages/api/controllers/hackathon_register_controller.go
+++ b/packages/api/controllers/hackathon_register_controller.go
@@ -172,7 +172,6 @@ func CompareTeamNames(passedTeamName string, storedTeamName string) bool {
 
 func IsRegistrationAvailable(c *fiber.Ctx) error {
 
-	SendEmailToNewParticipant("Viktor", "vikinaskotinka@gmail.com", "false")
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 

--- a/packages/web/src/feature_switches.js
+++ b/packages/web/src/feature_switches.js
@@ -1,6 +1,6 @@
 // easily disable sections globally
 const FEATURE_SWITCHES = {
-    jobs: true,
+    jobs: false,
     team: true,
     regForm: false
     // TODO: add feature switches for important components such as the registration form


### PR DESCRIPTION
Removed unnecessary code from hackathon registration controller. The removed code was initially used for dummy testing of the registration email confirmation on a single email account. This code should have been removed immediately after the completion of the personalized user testing results. 