### PR TITLE
Logger add fallback value for request ID

### DIFF
--- a/services/py-api/src/logger/logger_factory.py
+++ b/services/py-api/src/logger/logger_factory.py
@@ -123,7 +123,7 @@ class RequestIdFilter(Filter):
         # noinspection PyTypeChecker
         ctx: _StructlogContextVars = get_contextvars()
 
-        request_id = ctx["request_id"]
+        request_id = ctx.get("request_id", "")
         # Empty string so formatter with %(request_id)s never explodes
         record.request_id = request_id
         # Return True to allow the log record to be emitted


### PR DESCRIPTION
The application was crashing during deployment when trying to access ctx["request_id"]. This error could occur because not all log records have a request context during startup